### PR TITLE
Feature/match detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,9 @@ July 2024 Personal project, match table creation and management application
     - 상단바에 제목 출력
     - 서브 타이틀에 경기 수와 참가자 수 출력
   - Process 화면들 ScrollView 전체로 변경
-  - CalendarView 작업중
+  - CalendarView 추가
+    - 대회일자를 선택할 수 있는 캘린더 뷰 추가
+    - 캘린더 뷰를 통해 대회일자를 선택하면 MatchInfoFragment 에서 대회일자 자동 입력
+    - 변경되는 대회 일자에 따라 Title hint 변경
+    - MaterialCalendarView 는 충돌이 발생하여 일반 CalendarView 사용
+    - Dialog 형식으로 출력하고 ViewModel을 통해 데이터 주고받음

--- a/README.md
+++ b/README.md
@@ -136,9 +136,23 @@ July 2024 Personal project, match table creation and management application
     - 상단바에 제목 출력
     - 서브 타이틀에 경기 수와 참가자 수 출력
   - Process 화면들 ScrollView 전체로 변경
+
+## 2024.07.17
+- **Match Process 디테일 개발**
   - CalendarView 추가
     - 대회일자를 선택할 수 있는 캘린더 뷰 추가
     - 캘린더 뷰를 통해 대회일자를 선택하면 MatchInfoFragment 에서 대회일자 자동 입력
     - 변경되는 대회 일자에 따라 Title hint 변경
     - MaterialCalendarView 는 충돌이 발생하여 일반 CalendarView 사용
     - Dialog 형식으로 출력하고 ViewModel을 통해 데이터 주고받음
+  - Player, Game, Main Fragment 코드 정리
+  - Game, Main Fragment에서 네비게이션이 꼬이던 문제 해결
+  - MatchMainFragment 개발 완료
+    - ViewPager2 를 사용한 Tab 전환
+    - MatchMainListFragment, MatchMainRankFragment 연결
+  - MatchMainFragment 에서 Match 데이터를 가져와서 출력
+    - Match.matchList 를 가져와서 대진표 출력 (MatchMainListFragment)
+    - MatchMainListItem 디자인 수정 
+    - Match.players 를 가져와서 플레이어 목록 출력 (MatchMainRankFragment)
+      - 각 플레이어 별 승점에 따라 정렬 기능 구현 필요.
+  

--- a/README.md
+++ b/README.md
@@ -131,3 +131,9 @@ July 2024 Personal project, match table creation and management application
 - **MatchInfoDialog 개발**
     - Custom Dialog 를 만들어서 대회 정보를 출력하는 다이얼로그 개발
     - MatchMainFragment 에서 대회 정보를 출력하는 버튼 클릭 시 다이얼로그 출력
+- **Match Process 디테일 개발**
+  - MatchMain 정보 출력
+    - 상단바에 제목 출력
+    - 서브 타이틀에 경기 수와 참가자 수 출력
+  - Process 화면들 ScrollView 전체로 변경
+  - CalendarView 작업중

--- a/app/src/main/java/com/kuneosu/mintoners/ui/adapter/MatchMainListAdapter.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/adapter/MatchMainListAdapter.kt
@@ -1,0 +1,59 @@
+package com.kuneosu.mintoners.ui.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.kuneosu.mintoners.data.model.Game
+import com.kuneosu.mintoners.data.model.Match
+import com.kuneosu.mintoners.databinding.MatchMainListItemBinding
+import com.kuneosu.mintoners.ui.viewmodel.MatchViewModel
+import com.kuneosu.mintoners.util.ItemTouchHelperListener
+
+class MatchMainListAdapter(private val matchViewModel: MatchViewModel) :
+    ListAdapter<Game, MatchMainListAdapter.MatchViewHolder>(diffUtil), ItemTouchHelperListener {
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<Game>() {
+            override fun areItemsTheSame(oldItem: Game, newItem: Game): Boolean {
+                return oldItem.gameIndex == newItem.gameIndex
+            }
+
+            override fun areContentsTheSame(oldItem: Game, newItem: Game): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return currentList.size
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MatchViewHolder {
+        val binding =
+            MatchMainListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return MatchViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: MatchViewHolder, position: Int) {
+        holder.bind(currentList[position])
+    }
+
+    inner class MatchViewHolder(private val binding: MatchMainListItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(game: Game) {
+            binding.matchMainListPlayerA.text = game.gameTeamA[0].playerName
+            binding.matchMainListPlayerB.text = game.gameTeamA[1].playerName
+            binding.matchMainListPlayerC.text = game.gameTeamB[0].playerName
+            binding.matchMainListPlayerD.text = game.gameTeamB[1].playerName
+
+            binding.matchMainListTeamAScore.setText(game.gameAScore.toString())
+            binding.matchMainListTeamBScore.setText(game.gameBScore.toString())
+            binding.matchMainListNumber.text = game.gameIndex.toString()
+        }
+    }
+
+    override fun onSwiped(position: Int) {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/kuneosu/mintoners/ui/adapter/MatchMainPagerAdapter.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/adapter/MatchMainPagerAdapter.kt
@@ -1,0 +1,18 @@
+package com.kuneosu.mintoners.ui.adapter
+
+import android.util.Log
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+
+private const val TAG = "MatchMainPagerAdapter"
+
+class MatchMainPagerAdapter(
+    private val fragmentList: List<Fragment>,
+    fragment: Fragment
+) : FragmentStateAdapter(fragment) {
+
+    override fun getItemCount(): Int = fragmentList.size
+    override fun createFragment(position: Int): Fragment{
+        return fragmentList[position]
+    }
+}

--- a/app/src/main/java/com/kuneosu/mintoners/ui/adapter/MatchMainRankAdapter.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/adapter/MatchMainRankAdapter.kt
@@ -1,0 +1,54 @@
+package com.kuneosu.mintoners.ui.adapter
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.kuneosu.mintoners.data.model.Player
+import com.kuneosu.mintoners.databinding.MatchMainRankItemBinding
+import com.kuneosu.mintoners.ui.viewmodel.MatchViewModel
+import com.kuneosu.mintoners.util.ItemTouchHelperListener
+
+class MatchMainRankAdapter(private val matchViewModel: MatchViewModel) :
+    ListAdapter<Player, MatchMainRankAdapter.RankViewHolder>(diffUtil), ItemTouchHelperListener {
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<Player>() {
+            override fun areItemsTheSame(oldItem: Player, newItem: Player): Boolean {
+                return oldItem.playerIndex == newItem.playerIndex
+            }
+
+            override fun areContentsTheSame(oldItem: Player, newItem: Player): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return currentList.size
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RankViewHolder {
+        val binding =
+            MatchMainRankItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return RankViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: RankViewHolder, position: Int) {
+        holder.bind(currentList[position])
+    }
+
+    inner class RankViewHolder(private val binding: MatchMainRankItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        @SuppressLint("SetTextI18n")
+        fun bind(player: Player) {
+            binding.matchMainRankName.text = player.playerName
+            binding.matchMainRankNumber.text = (adapterPosition + 1).toString()
+        }
+    }
+
+    override fun onSwiped(position: Int) {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/kuneosu/mintoners/ui/adapter/MatchPlayerAdapter.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/adapter/MatchPlayerAdapter.kt
@@ -1,6 +1,8 @@
 package com.kuneosu.mintoners.ui.adapter
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -43,9 +45,11 @@ class MatchPlayerAdapter(private val matchViewModel: MatchViewModel) :
     }
 
     private fun deletePlayer(player: Player) {
-        matchViewModel.deletePlayer(player)
-        matchViewModel.updatePlayerIndexes()
-        notifyItemRangeChanged(0, currentList.size)
+        Handler(Looper.getMainLooper()).post {
+            matchViewModel.deletePlayer(player)
+            matchViewModel.updatePlayerIndexes()
+            notifyItemRangeChanged(0, currentList.size)
+        }
     }
 
     private fun updatePlayer(player: Player) {
@@ -106,14 +110,18 @@ class MatchPlayerAdapter(private val matchViewModel: MatchViewModel) :
                     if (newName.isNotEmpty()) {
                         updatePlayer(player)
                     } else {
-                        deletePlayer(player)
+                        Handler(Looper.getMainLooper()).post {
+                            deletePlayer(player)
+                        }
                     }
 
                 }
             }
 
             binding.deleteButton.setOnClickListener {
-                deletePlayer(player)
+                Handler(Looper.getMainLooper()).post {
+                    deletePlayer(player)
+                }
             }
 
             if (focusChecker) {

--- a/app/src/main/java/com/kuneosu/mintoners/ui/customview/MatchCalendarDialog.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/customview/MatchCalendarDialog.kt
@@ -2,13 +2,20 @@ package com.kuneosu.mintoners.ui.customview
 
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.RequiresApi
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import com.kuneosu.mintoners.databinding.MatchCalendarDialogBinding
-import com.kuneosu.mintoners.databinding.MatchInfoDialogBinding
+import com.kuneosu.mintoners.ui.viewmodel.MatchViewModel
+import java.time.LocalDate
+import java.util.Calendar
+
 
 class MatchCalendarDialog(
 ) : DialogFragment() {
@@ -16,7 +23,9 @@ class MatchCalendarDialog(
     // 뷰 바인딩 정의
     private var _binding: MatchCalendarDialogBinding? = null
     private val binding get() = _binding!!
+    private val matchViewModel: MatchViewModel by activityViewModels()
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -28,6 +37,24 @@ class MatchCalendarDialog(
         // 레이아웃 배경을 투명하게 해줌, 필수 아님
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
+        matchViewModel.selectedDate.value?.let { date ->
+            val parts = date.split("-")
+            if (parts.size == 3) {
+                val year = parts[0].toInt()
+                val month = parts[1].toInt() - 1 // CalendarView의 month는 0부터 시작
+                val day = parts[2].toInt()
+                val calendar = Calendar.getInstance()
+                calendar.set(year, month, day)
+                binding.matchCalendarView.date = calendar.timeInMillis
+            }
+        }
+        binding.matchCalendarView.setOnDateChangeListener { _, year, month, dayOfMonth ->
+            val monthStr = if (month + 1 < 10) "0${month + 1}" else "${month + 1}"
+            val dayStr = if (dayOfMonth < 10) "0$dayOfMonth" else "$dayOfMonth"
+            val date = "$year-$monthStr-$dayStr"
+            matchViewModel.setSelectedDate(date)
+        }
+
 
         // 취소 버튼 클릭
         binding.matchCalendarClose.setOnClickListener {
@@ -36,7 +63,6 @@ class MatchCalendarDialog(
 
         return view
     }
-
 
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/kuneosu/mintoners/ui/customview/MatchCalendarDialog.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/customview/MatchCalendarDialog.kt
@@ -1,0 +1,46 @@
+package com.kuneosu.mintoners.ui.customview
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.kuneosu.mintoners.databinding.MatchCalendarDialogBinding
+import com.kuneosu.mintoners.databinding.MatchInfoDialogBinding
+
+class MatchCalendarDialog(
+) : DialogFragment() {
+
+    // 뷰 바인딩 정의
+    private var _binding: MatchCalendarDialogBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = MatchCalendarDialogBinding.inflate(inflater, container, false)
+        val view = binding.root
+
+        // 레이아웃 배경을 투명하게 해줌, 필수 아님
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+
+        // 취소 버튼 클릭
+        binding.matchCalendarClose.setOnClickListener {
+            dismiss()
+        }
+
+        return view
+    }
+
+
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchGameFragment.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchGameFragment.kt
@@ -1,11 +1,13 @@
 package com.kuneosu.mintoners.ui.fragments
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
@@ -15,7 +17,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.kuneosu.mintoners.R
 import com.kuneosu.mintoners.databinding.FragmentMatchGameBinding
 import com.kuneosu.mintoners.ui.adapter.MatchGamesAdapter
-import com.kuneosu.mintoners.ui.adapter.MatchPlayerAdapter
 import com.kuneosu.mintoners.ui.viewmodel.MatchViewModel
 import com.kuneosu.mintoners.util.SimpleSwipeHelperCallback
 import dagger.hilt.android.AndroidEntryPoint
@@ -33,14 +34,50 @@ class MatchGameFragment : Fragment() {
     ): View {
         _binding = FragmentMatchGameBinding.inflate(inflater, container, false)
 
+        gameAdapterSetting()
+
+        binding.matchGameLoadButton.setOnClickListener {
+            matchViewModel.generateGames()
+        }
+
+        gameNavigationSetting()
+
+        return binding.root
+    }
+
+    private fun gameNavigationSetting() {
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (binding.matchGameRoot.hasFocus()) {
+                        binding.matchGameRoot.clearFocus()
+                        hideKeyboard()
+                    } else {
+                        findNavController().popBackStack()
+                        matchViewModel.applyGameList()
+                    }
+                }
+            })
+
+        binding.matchGamePreviousButton.setOnClickListener {
+            findNavController().popBackStack()
+            matchViewModel.applyGameList()
+        }
+
+        binding.matchGameNextButton.setOnClickListener {
+            findNavController().navigate(R.id.action_matchGameFragment_to_matchMainFragment)
+            matchViewModel.applyGameList()
+        }
+    }
+
+    private fun gameAdapterSetting() {
         adapter = MatchGamesAdapter(matchViewModel)
         binding.matchGameRecyclerView.adapter = adapter
         binding.matchGameRecyclerView.layoutManager = LinearLayoutManager(context)
 
         val swipeHelper = ItemTouchHelper(SimpleSwipeHelperCallback(adapter))
         swipeHelper.attachToRecyclerView(binding.matchGameRecyclerView)
-
-
 
         matchViewModel.games.observe(viewLifecycleOwner, Observer {
             if (it.isEmpty()) {
@@ -49,22 +86,12 @@ class MatchGameFragment : Fragment() {
             adapter.submitList(it)
             updateGameCount(it.size)
         })
+    }
 
-        binding.matchGameLoadButton.setOnClickListener {
-            matchViewModel.generateGames()
-        }
-
-        binding.matchGamePreviousButton.setOnClickListener {
-            findNavController().navigate(R.id.action_matchGameFragment_to_matchPlayerFragment)
-            matchViewModel.applyGameList()
-        }
-
-        binding.matchGameNextButton.setOnClickListener {
-            findNavController().navigate(R.id.action_matchGameFragment_to_matchMainFragment)
-            matchViewModel.applyGameList()
-        }
-
-        return binding.root
+    private fun hideKeyboard() {
+        val inputMethodManager =
+            activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(view?.windowToken, 0)
     }
 
     @SuppressLint("SetTextI18n")

--- a/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchInfoFragment.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchInfoFragment.kt
@@ -4,14 +4,12 @@ import android.annotation.SuppressLint
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
-import android.text.Editable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.kuneosu.mintoners.R
 import com.kuneosu.mintoners.data.model.Match
@@ -32,37 +30,39 @@ class MatchInfoFragment : Fragment() {
     private val binding get() = _binding!!
     private val matchViewModel: MatchViewModel by activityViewModels()
 
-
     @RequiresApi(Build.VERSION_CODES.O)
-    @SuppressLint("SetTextI18n")
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentMatchInfoBinding.inflate(inflater, container, false)
 
-        binding.matchInfoGameTypeInput.setOnCheckedChangeListener { group, checkedId ->
-            matchTypeRadioChanged(checkedId)
-        }
+        matchTypeRadioChanged()
 
+        matchGameCountChanged()
+
+        saveMatchOnNextButtonClicked()
+
+
+        setCalendarViewEvent()
+
+        return binding.root
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun setCalendarViewEvent() {
+        matchViewModel.selectedDate.observe(viewLifecycleOwner) {
+            binding.matchInfoDateInput.text = it
+            infoNameHint()
+        }
 
         binding.matchInfoDateInput.setOnClickListener {
             val dialog = MatchCalendarDialog()
-            dialog.show(childFragmentManager, "calendar")
+            dialog.show(childFragmentManager, "MatchCalendarDialog")
         }
+    }
 
-        binding.matchInfoGameCountMinus.setOnClickListener {
-            val currentCount = binding.matchInfoGameCountNumber.text.toString().toInt()
-            if (currentCount > 1) {
-                binding.matchInfoGameCountNumber.text = (currentCount - 1).toString()
-            }
-        }
-
-        binding.matchInfoGameCountPlus.setOnClickListener {
-            val currentCount = binding.matchInfoGameCountNumber.text.toString().toInt()
-            binding.matchInfoGameCountNumber.text = (currentCount + 1).toString()
-        }
-
+    private fun saveMatchOnNextButtonClicked() {
         binding.matchInfoNextButton.setOnClickListener {
             val points =
                 "${binding.matchInfoScoreWinInput.text}${binding.matchInfoScoreDrawInput.text}${binding.matchInfoScoreLoseInput.text}"
@@ -76,21 +76,20 @@ class MatchInfoFragment : Fragment() {
             )
             findNavController().navigate(R.id.action_matchInfoFragment_to_matchPlayerFragment)
         }
+    }
 
-        binding.matchInfoNameHintOne.text = infoNameHint(1)
-        binding.matchInfoNameHintTwo.text = infoNameHint(2)
-
-        binding.matchInfoNameHintOne.setOnClickListener {
-            binding.matchInfoNameInput.setText(binding.matchInfoNameHintOne.text)
+    @SuppressLint("SetTextI18n")
+    private fun matchGameCountChanged() {
+        binding.matchInfoGameCountMinus.setOnClickListener {
+            val currentCount = binding.matchInfoGameCountNumber.text.toString().toInt()
+            if (currentCount > 1) {
+                binding.matchInfoGameCountNumber.text = (currentCount - 1).toString()
+            }
         }
-        binding.matchInfoNameHintTwo.setOnClickListener {
-            binding.matchInfoNameInput.setText(binding.matchInfoNameHintTwo.text)
+        binding.matchInfoGameCountPlus.setOnClickListener {
+            val currentCount = binding.matchInfoGameCountNumber.text.toString().toInt()
+            binding.matchInfoGameCountNumber.text = (currentCount + 1).toString()
         }
-
-        binding.matchInfoDateInput.text = Editable.Factory.getInstance()
-            .newEditable((LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
-
-        return binding.root
     }
 
     private fun onNextClicked(
@@ -113,28 +112,32 @@ class MatchInfoFragment : Fragment() {
     }
 
 
-    private fun matchTypeRadioChanged(checkedId: Int) {
-        when (checkedId) {
-            binding.matchInfoGameTypeDouble.id -> {
-                binding.matchInfoGameTypeDouble.setTextColor(Color.WHITE)
-                binding.matchInfoGameTypeSingle.setTextColor(
-                    resources.getColor(
-                        R.color.main,
-                        null
-                    )
-                )
-            }
+    private fun matchTypeRadioChanged() {
 
-            binding.matchInfoGameTypeSingle.id -> {
-                binding.matchInfoGameTypeDouble.setTextColor(
-                    resources.getColor(
-                        R.color.main,
-                        null
+        binding.matchInfoGameTypeInput.setOnCheckedChangeListener { _, checkedId ->
+            when (checkedId) {
+                binding.matchInfoGameTypeDouble.id -> {
+                    binding.matchInfoGameTypeDouble.setTextColor(Color.WHITE)
+                    binding.matchInfoGameTypeSingle.setTextColor(
+                        resources.getColor(
+                            R.color.main,
+                            null
+                        )
                     )
-                )
-                binding.matchInfoGameTypeSingle.setTextColor(Color.WHITE)
+                }
+
+                binding.matchInfoGameTypeSingle.id -> {
+                    binding.matchInfoGameTypeDouble.setTextColor(
+                        resources.getColor(
+                            R.color.main,
+                            null
+                        )
+                    )
+                    binding.matchInfoGameTypeSingle.setTextColor(Color.WHITE)
+                }
             }
         }
+
     }
 
     private fun stringToDate(dateString: String): Date? {
@@ -143,23 +146,27 @@ class MatchInfoFragment : Fragment() {
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun infoNameHint(type: Int): String {
-        val today = LocalDate.now()
+    private fun infoNameHint() {
+        val date = LocalDate.parse(matchViewModel.selectedDate.value)
 
         // 날짜를 "yyyy-MM-dd" 형식으로 포맷터를 만듦
         val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
         val dateFormatterTwo = DateTimeFormatter.ofPattern("yyyy-MM")
         // 요일을 가져옴 (한국어로)
-        val dayOfWeek = today.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.KOREAN)
+        val dayOfWeek = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.KOREAN)
         // 최종 문자열을 만듦
-        val hintOne = "${today.format(dateFormatter)} ($dayOfWeek)"
-        val hintTwo = "${today.format(dateFormatterTwo)} 월례대회"
+        val hintOne = "${date.format(dateFormatter)} ($dayOfWeek)"
+        val hintTwo = "${date.format(dateFormatterTwo)} 월례대회"
 
-        when (type) {
-            1 -> return hintOne
-            2 -> return hintTwo
+        binding.matchInfoNameHintOne.text = hintOne
+        binding.matchInfoNameHintTwo.text = hintTwo
+
+        binding.matchInfoNameHintOne.setOnClickListener {
+            binding.matchInfoNameInput.setText(hintOne)
         }
-        return ""
+        binding.matchInfoNameHintTwo.setOnClickListener {
+            binding.matchInfoNameInput.setText(hintTwo)
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchInfoFragment.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchInfoFragment.kt
@@ -43,7 +43,6 @@ class MatchInfoFragment : Fragment() {
 
         saveMatchOnNextButtonClicked()
 
-
         setCalendarViewEvent()
 
         return binding.root

--- a/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchInfoFragment.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchInfoFragment.kt
@@ -16,6 +16,7 @@ import androidx.navigation.fragment.findNavController
 import com.kuneosu.mintoners.R
 import com.kuneosu.mintoners.data.model.Match
 import com.kuneosu.mintoners.databinding.FragmentMatchInfoBinding
+import com.kuneosu.mintoners.ui.customview.MatchCalendarDialog
 import com.kuneosu.mintoners.ui.viewmodel.MatchViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import java.text.SimpleDateFormat
@@ -45,6 +46,10 @@ class MatchInfoFragment : Fragment() {
         }
 
 
+        binding.matchInfoDateInput.setOnClickListener {
+            val dialog = MatchCalendarDialog()
+            dialog.show(childFragmentManager, "calendar")
+        }
 
         binding.matchInfoGameCountMinus.setOnClickListener {
             val currentCount = binding.matchInfoGameCountNumber.text.toString().toInt()

--- a/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchMainFragment.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchMainFragment.kt
@@ -1,5 +1,6 @@
 package com.kuneosu.mintoners.ui.fragments
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -24,23 +25,37 @@ class MatchMainFragment : Fragment() {
     private val matchViewModel: MatchViewModel by activityViewModels()
 
 
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentMatchMainBinding.inflate(inflater, container, false)
 
-        infoDialogSetting()
 
+        displayInfoSetting()
+        infoDialogSetting()
+        moveButtonSetting()
+
+
+        return binding.root
+    }
+
+    @SuppressLint("SetTextI18n")
+    private fun displayInfoSetting() {
+        binding.matchMainTopTitle.text = matchViewModel.match.value?.matchName ?: ""
+        binding.matchMainCountText.text = "" +
+                "참가 인원 : ${matchViewModel.match.value?.matchPlayers?.size ?: 0}명\n" +
+                "총 경기 수 : ${matchViewModel.match.value?.matchList?.size ?: 0}경기"
+    }
+
+    private fun moveButtonSetting() {
         binding.matchMainEditButton.setOnClickListener {
             findNavController().navigate(R.id.action_matchMainFragment_to_matchGameFragment)
         }
-
         binding.matchMainEndButton.setOnClickListener {
             activity?.finish()
         }
-
-        return binding.root
     }
 
     private fun infoDialogSetting() {

--- a/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchMainFragment.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchMainFragment.kt
@@ -1,16 +1,22 @@
 package com.kuneosu.mintoners.ui.fragments
 
 import android.annotation.SuppressLint
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayoutMediator
 import com.kuneosu.mintoners.R
 import com.kuneosu.mintoners.databinding.FragmentMatchMainBinding
+import com.kuneosu.mintoners.ui.adapter.MatchMainPagerAdapter
 import com.kuneosu.mintoners.ui.customview.MatchInfoDialog
 import com.kuneosu.mintoners.ui.viewmodel.MatchViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -25,7 +31,6 @@ class MatchMainFragment : Fragment() {
     private val matchViewModel: MatchViewModel by activityViewModels()
 
 
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -36,9 +41,37 @@ class MatchMainFragment : Fragment() {
         displayInfoSetting()
         infoDialogSetting()
         moveButtonSetting()
+        initPager()
+
+        binding.matchMainEndButton.setOnClickListener {
+
+            activity?.finish()
+        }
 
 
         return binding.root
+    }
+
+    private fun initPager() {
+        val viewPager = binding.matchMainViewPager
+        val tabLayout = binding.matchMainTab
+
+        val fragmentList = listOf(
+            MatchMainListFragment(),
+            MatchMainRankFragment(),
+        )
+
+
+        viewPager.adapter =
+            MatchMainPagerAdapter(fragmentList, this)
+
+        TabLayoutMediator(tabLayout, viewPager) { tab, position ->
+            when (position) {
+                0 -> tab.text = "대진표"
+                1 -> tab.text = "현재 순위"
+            }
+        }.attach()
+
     }
 
     @SuppressLint("SetTextI18n")

--- a/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchMainListFragment.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchMainListFragment.kt
@@ -1,23 +1,29 @@
 package com.kuneosu.mintoners.ui.fragments
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.kuneosu.mintoners.data.model.Game
 import com.kuneosu.mintoners.data.model.Player
 import com.kuneosu.mintoners.databinding.FragmentMatchMainListBinding
+import com.kuneosu.mintoners.ui.adapter.MatchMainListAdapter
 import com.kuneosu.mintoners.ui.viewmodel.MatchViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
+
+private const val TAG = "MatchMainListFragment"
 
 @AndroidEntryPoint
 class MatchMainListFragment : Fragment() {
     private var _binding: FragmentMatchMainListBinding? = null
     private val binding get() = _binding!!
     private val matchViewModel: MatchViewModel by activityViewModels()
+    private lateinit var matchMainListAdapter: MatchMainListAdapter
 
 
     override fun onCreateView(
@@ -26,29 +32,16 @@ class MatchMainListFragment : Fragment() {
     ): View {
         _binding = FragmentMatchMainListBinding.inflate(inflater, container, false)
 
-        onGenerateGames()
+        matchMainListAdapter = MatchMainListAdapter(matchViewModel)
+        binding.matchMainListRecyclerView.adapter = matchMainListAdapter
+        matchViewModel.match.observe(viewLifecycleOwner) {
+            matchMainListAdapter.submitList(it.matchList)
+        }
 
-        // adapter 를 통해 게임 목록을 표시
+        binding.matchMainListRecyclerView.layoutManager = LinearLayoutManager(context)
 
 
         return binding.root
-    }
-
-    private fun onGenerateGames() {
-        val players = matchViewModel.match.value?.matchPlayers ?: return
-
-        // Generate games based on players
-        val games = generateGames(players)
-
-        games.forEach { game ->
-            matchViewModel.addGame(game)
-        }
-    }
-
-    private fun generateGames(players: List<Player>): List<Game> {
-        // Game generation logic
-        // 대진표 생성 알고리즘을 통해 게임 목록 반환
-        return emptyList()
     }
 
 

--- a/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchMainRankFragment.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchMainRankFragment.kt
@@ -1,21 +1,28 @@
 package com.kuneosu.mintoners.ui.fragments
 
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.kuneosu.mintoners.R
 import com.kuneosu.mintoners.databinding.FragmentMatchMainRankBinding
+import com.kuneosu.mintoners.ui.adapter.MatchMainRankAdapter
 import com.kuneosu.mintoners.ui.viewmodel.MatchViewModel
 import dagger.hilt.android.AndroidEntryPoint
+
+private const val TAG = "MatchMainRankFragment"
 
 @AndroidEntryPoint
 class MatchMainRankFragment : Fragment() {
     private var _binding: FragmentMatchMainRankBinding? = null
     private val binding get() = _binding!!
-    private val matchViewModel: MatchViewModel by viewModels()
+    private val matchViewModel: MatchViewModel by activityViewModels()
+    private lateinit var matchMainRankAdapter: MatchMainRankAdapter
 
 
     override fun onCreateView(
@@ -23,6 +30,15 @@ class MatchMainRankFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentMatchMainRankBinding.inflate(inflater, container, false)
+
+        matchMainRankAdapter = MatchMainRankAdapter(matchViewModel)
+        binding.matchMainRankRecyclerView.adapter = matchMainRankAdapter
+        matchViewModel.match.observe(viewLifecycleOwner) {
+            matchMainRankAdapter.submitList(it.matchPlayers)
+        }
+        binding.matchMainRankRecyclerView.layoutManager = LinearLayoutManager(context)
+
+
         return binding.root
     }
 

--- a/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchPlayerFragment.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/fragments/MatchPlayerFragment.kt
@@ -42,20 +42,16 @@ class MatchPlayerFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        adapter = MatchPlayerAdapter(matchViewModel)
-        binding.matchPlayerRecyclerView.adapter = adapter
-        binding.matchPlayerRecyclerView.layoutManager = LinearLayoutManager(context)
-
-        matchViewModel.players.observe(viewLifecycleOwner, Observer {
-            adapter.submitList(it)
-            updatePlayerCount(it.size)
-        })
+        playerAdapterSetting()
 
         binding.matchPlayerLoadButton.setOnClickListener {
             Log.d("MatchPlayerFragment", "onViewCreated: ${matchViewModel.match.value}")
         }
 
+        playerNavigationSetting()
+    }
 
+    private fun playerNavigationSetting() {
         // Set OnTouchListener to root layout to detect touch events
         binding.matchPlayerCard.setOnTouchListener { v, event ->
             if (event.action == MotionEvent.ACTION_DOWN) {
@@ -89,6 +85,17 @@ class MatchPlayerFragment : Fragment() {
             findNavController().navigate(R.id.action_matchPlayerFragment_to_matchGameFragment)
             matchViewModel.applyPlayerList()
         }
+    }
+
+    private fun playerAdapterSetting() {
+        adapter = MatchPlayerAdapter(matchViewModel)
+        binding.matchPlayerRecyclerView.adapter = adapter
+        binding.matchPlayerRecyclerView.layoutManager = LinearLayoutManager(context)
+
+        matchViewModel.players.observe(viewLifecycleOwner, Observer {
+            adapter.submitList(it)
+            updatePlayerCount(it.size)
+        })
     }
 
     @SuppressLint("SetTextI18n")

--- a/app/src/main/java/com/kuneosu/mintoners/ui/viewmodel/MatchViewModel.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/viewmodel/MatchViewModel.kt
@@ -9,7 +9,9 @@ import com.kuneosu.mintoners.data.model.Match
 import com.kuneosu.mintoners.data.model.Player
 import com.kuneosu.mintoners.data.repository.MatchRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 
@@ -35,6 +37,7 @@ class MatchViewModel @Inject constructor(
     init {
         _players.value = _match.value?.matchPlayers ?: listOf()
         _games.value = _match.value?.matchList ?: listOf()
+        _selectedDate.value = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
     }
 
     fun setSelectedDate(date: String) {
@@ -48,9 +51,8 @@ class MatchViewModel @Inject constructor(
         Log.d(TAG, "createMatch: $match")
     }
 
-    fun updateMatch(match: Match) {
-        repository.updateMatch(match)
-        _match.value = match
+    fun updateMatch() {
+        repository.updateMatch(_match.value!!)
     }
 
     fun addPlayer(player: Player) {
@@ -71,6 +73,7 @@ class MatchViewModel @Inject constructor(
     fun applyPlayerList() {
         val currentList = _players.value.orEmpty().toMutableList()
         _match.value?.matchPlayers = currentList
+        updateMatch()
     }
 
     fun deletePlayer(player: Player) {
@@ -124,6 +127,7 @@ class MatchViewModel @Inject constructor(
     fun applyGameList() {
         val currentList = _games.value.orEmpty().toMutableList()
         _match.value?.matchList = currentList
+        updateMatch()
     }
 
     private fun gameMakingWithKdk(): List<Game> {

--- a/app/src/main/java/com/kuneosu/mintoners/ui/viewmodel/MatchViewModel.kt
+++ b/app/src/main/java/com/kuneosu/mintoners/ui/viewmodel/MatchViewModel.kt
@@ -9,6 +9,7 @@ import com.kuneosu.mintoners.data.model.Match
 import com.kuneosu.mintoners.data.model.Player
 import com.kuneosu.mintoners.data.repository.MatchRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.Date
 import javax.inject.Inject
 
 
@@ -28,9 +29,16 @@ class MatchViewModel @Inject constructor(
     private val _games = MutableLiveData<List<Game>>()
     val games: LiveData<List<Game>> get() = _games
 
+    private val _selectedDate = MutableLiveData<String>()
+    val selectedDate: LiveData<String> get() = _selectedDate
+
     init {
         _players.value = _match.value?.matchPlayers ?: listOf()
         _games.value = _match.value?.matchList ?: listOf()
+    }
+
+    fun setSelectedDate(date: String) {
+        _selectedDate.value = date
     }
 
 

--- a/app/src/main/res/drawable/selector_match_calendar.xml
+++ b/app/src/main/res/drawable/selector_match_calendar.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_activated="true" android:color="@color/white" />
+    <item android:state_enabled="false" android:color="@color/trans_black_50"/>
+    <item android:color="@color/black" />
+</selector>

--- a/app/src/main/res/layout/fragment_match_game.xml
+++ b/app/src/main/res/layout/fragment_match_game.xml
@@ -8,204 +8,212 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    tools:context=".ui.fragments.MatchListFragment">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/match_game_top_bar"
-        android:layout_width="match_parent"
-        android:layout_height="160dp"
-        android:background="@color/main"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/match_game_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_medium"
-            android:text="대진표 생성"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_2xlarge"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/white"
-            app:layout_constraintBottom_toBottomOf="@id/match_game_top_bar"
-            app:layout_constraintTop_toBottomOf="@id/match_game_title" />
-
-        <TextView
-            android:id="@+id/match_game_process_one"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="@drawable/match_process_unselected"
-            android:gravity="center"
-            android:text="1"
-            android:textAlignment="center"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_medium"
-            app:layout_constraintBottom_toBottomOf="@+id/match_game_top_bar"
-            app:layout_constraintEnd_toStartOf="@+id/match_game_process_two"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/match_game_title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_xsmall"
-            android:text="기본정보"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_small"
-            app:layout_constraintEnd_toEndOf="@id/match_game_process_one"
-            app:layout_constraintStart_toStartOf="@+id/match_game_process_one"
-            app:layout_constraintTop_toBottomOf="@id/match_game_process_one" />
-
-        <TextView
-            android:id="@+id/match_game_process_two"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginHorizontal="@dimen/margin_xlarge"
-            android:background="@drawable/match_process_unselected"
-            android:gravity="center"
-            android:text="2"
-            android:textAlignment="center"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_medium"
-            app:layout_constraintBottom_toBottomOf="@+id/match_game_top_bar"
-            app:layout_constraintEnd_toStartOf="@id/match_game_process_three"
-            app:layout_constraintStart_toEndOf="@+id/match_game_process_one"
-            app:layout_constraintTop_toBottomOf="@+id/match_game_title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_xsmall"
-            android:text="참가자"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_small"
-            app:layout_constraintEnd_toEndOf="@id/match_game_process_two"
-            app:layout_constraintStart_toStartOf="@+id/match_game_process_two"
-            app:layout_constraintTop_toBottomOf="@id/match_game_process_two" />
-
-        <TextView
-            android:id="@+id/match_game_process_three"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="@drawable/match_process_selected"
-            android:gravity="center"
-            android:text="3"
-            android:textAlignment="center"
-            android:textColor="@color/main"
-            android:textSize="@dimen/text_medium"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="@+id/match_game_top_bar"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/match_game_process_two"
-            app:layout_constraintTop_toBottomOf="@+id/match_game_title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_xsmall"
-            android:text="대진표작성"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_small"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="@id/match_game_process_three"
-            app:layout_constraintStart_toStartOf="@+id/match_game_process_three"
-            app:layout_constraintTop_toBottomOf="@id/match_game_process_three" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    tools:context=".ui.fragments.MatchGameFragment">
 
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/match_game_top_bar">
+        app:layout_constraintTop_toTopOf="parent">
 
-        <com.kuneosu.mintoners.ui.customview.CustomConstraint
-            android:id="@+id/match_game_card"
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/bottom_app_bar_height">
-
+            android:layout_height="wrap_content">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/match_game_card_title"
+                android:id="@+id/match_game_top_bar"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/margin_default"
+                android:layout_height="160dp"
+                android:background="@color/main"
                 app:layout_constraintTop_toTopOf="parent">
 
                 <TextView
-                    android:id="@+id/match_game_count_text"
+                    android:id="@+id/match_game_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="참가 인원수 : N 명\n경기 수 : N 경기"
-                    android:textColor="@color/black"
-                    android:textSize="@dimen/text_large"
-                    app:layout_constraintBottom_toBottomOf="@+id/match_game_load_button"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:text="대진표 생성"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_2xlarge"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/match_game_load_button" />
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/white"
+                    app:layout_constraintBottom_toBottomOf="@id/match_game_top_bar"
+                    app:layout_constraintTop_toBottomOf="@id/match_game_title" />
+
+                <TextView
+                    android:id="@+id/match_game_process_one"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:background="@drawable/match_process_unselected"
+                    android:gravity="center"
+                    android:text="1"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_medium"
+                    app:layout_constraintBottom_toBottomOf="@+id/match_game_top_bar"
+                    app:layout_constraintEnd_toStartOf="@+id/match_game_process_two"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/match_game_title" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_xsmall"
+                    android:text="기본정보"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_small"
+                    app:layout_constraintEnd_toEndOf="@id/match_game_process_one"
+                    app:layout_constraintStart_toStartOf="@+id/match_game_process_one"
+                    app:layout_constraintTop_toBottomOf="@id/match_game_process_one" />
+
+                <TextView
+                    android:id="@+id/match_game_process_two"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginHorizontal="@dimen/margin_xlarge"
+                    android:background="@drawable/match_process_unselected"
+                    android:gravity="center"
+                    android:text="2"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_medium"
+                    app:layout_constraintBottom_toBottomOf="@+id/match_game_top_bar"
+                    app:layout_constraintEnd_toStartOf="@id/match_game_process_three"
+                    app:layout_constraintStart_toEndOf="@+id/match_game_process_one"
+                    app:layout_constraintTop_toBottomOf="@+id/match_game_title" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_xsmall"
+                    android:text="참가자"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_small"
+                    app:layout_constraintEnd_toEndOf="@id/match_game_process_two"
+                    app:layout_constraintStart_toStartOf="@+id/match_game_process_two"
+                    app:layout_constraintTop_toBottomOf="@id/match_game_process_two" />
+
+                <TextView
+                    android:id="@+id/match_game_process_three"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:background="@drawable/match_process_selected"
+                    android:gravity="center"
+                    android:text="3"
+                    android:textAlignment="center"
+                    android:textColor="@color/main"
+                    android:textSize="@dimen/text_medium"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="@+id/match_game_top_bar"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/match_game_process_two"
+                    app:layout_constraintTop_toBottomOf="@+id/match_game_title" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_xsmall"
+                    android:text="대진표작성"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_small"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="@id/match_game_process_three"
+                    app:layout_constraintStart_toStartOf="@+id/match_game_process_three"
+                    app:layout_constraintTop_toBottomOf="@id/match_game_process_three" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+            <com.kuneosu.mintoners.ui.customview.CustomConstraint
+                android:id="@+id/match_game_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="@dimen/bottom_app_bar_height"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/match_game_top_bar">
+
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/match_game_card_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/margin_default"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <TextView
+                        android:id="@+id/match_game_count_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="참가 인원수 : N 명\n경기 수 : N 경기"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/text_large"
+                        app:layout_constraintBottom_toBottomOf="@+id/match_game_load_button"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="@+id/match_game_load_button" />
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/match_game_load_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="@dimen/small_button_height"
+                        android:background="@drawable/match_main_button"
+                        android:paddingHorizontal="@dimen/padding_small"
+                        android:text="대진 순서 섞기"
+                        android:textColor="@color/white"
+                        android:textSize="@dimen/text_large"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <View
+                    android:id="@+id/match_game_card_title_divider"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="@dimen/margin_default"
+                    android:background="@color/trans_black_50"
+                    app:layout_constraintTop_toBottomOf="@+id/match_game_card_title" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/match_game_recycler_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toBottomOf="@id/match_game_card_title_divider" />
 
                 <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/match_game_load_button"
+                    android:id="@+id/match_game_previous_button"
                     android:layout_width="wrap_content"
                     android:layout_height="@dimen/small_button_height"
+                    android:layout_marginStart="@dimen/margin_default"
+                    android:layout_marginTop="@dimen/margin_xlarge"
+                    android:background="@drawable/match_sub_button"
+                    android:text="이전"
+                    android:textColor="@color/main"
+                    android:textSize="@dimen/text_large"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/match_game_recycler_view" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/match_game_next_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/small_button_height"
+                    android:layout_marginTop="@dimen/margin_xlarge"
+                    android:layout_marginEnd="@dimen/margin_default"
                     android:background="@drawable/match_main_button"
                     android:paddingHorizontal="@dimen/padding_small"
-                    android:text="대진 순서 섞기"
+                    android:text="대진표 생성"
                     android:textColor="@color/white"
                     android:textSize="@dimen/text_large"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <View
-                android:id="@+id/match_game_card_title_divider"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginTop="@dimen/margin_default"
-                android:background="@color/trans_black_50"
-                app:layout_constraintTop_toBottomOf="@+id/match_game_card_title" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/match_game_recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@id/match_game_card_title_divider" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/match_game_previous_button"
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/small_button_height"
-                android:layout_marginStart="@dimen/margin_default"
-                android:layout_marginTop="@dimen/margin_xlarge"
-                android:background="@drawable/match_sub_button"
-                android:text="이전"
-                android:textColor="@color/main"
-                android:textSize="@dimen/text_large"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_game_recycler_view" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/match_game_next_button"
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/small_button_height"
-                android:layout_marginTop="@dimen/margin_xlarge"
-                android:layout_marginEnd="@dimen/margin_default"
-                android:background="@drawable/match_main_button"
-                android:paddingHorizontal="@dimen/padding_small"
-                android:text="대진표 생성"
-                android:textColor="@color/white"
-                android:textSize="@dimen/text_large"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_game_recycler_view" />
+                    app:layout_constraintTop_toBottomOf="@id/match_game_recycler_view" />
 
 
-        </com.kuneosu.mintoners.ui.customview.CustomConstraint>
+            </com.kuneosu.mintoners.ui.customview.CustomConstraint>
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 
 </com.kuneosu.mintoners.ui.customview.CustomConstraint>

--- a/app/src/main/res/layout/fragment_match_info.xml
+++ b/app/src/main/res/layout/fragment_match_info.xml
@@ -9,412 +9,418 @@
     android:background="@color/white"
     tools:context=".ui.fragments.MatchInfoFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/match_info_top_bar"
-        android:layout_width="match_parent"
-        android:layout_height="160dp"
-        android:background="@color/main"
-        app:layout_constraintTop_toTopOf="parent">\
-
-        <TextView
-            android:id="@+id/match_info_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_medium"
-            android:text="대진표 생성"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_2xlarge"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/white"
-            app:layout_constraintBottom_toBottomOf="@id/match_info_top_bar"
-            app:layout_constraintTop_toBottomOf="@id/match_info_title" />
-
-        <TextView
-            android:id="@+id/match_info_process_one"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="@drawable/match_process_selected"
-            android:gravity="center"
-            android:text="1"
-            android:textAlignment="center"
-            android:textColor="@color/main"
-            android:textSize="@dimen/text_medium"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="@+id/match_info_top_bar"
-            app:layout_constraintEnd_toStartOf="@+id/match_info_process_two"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/match_info_title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_xsmall"
-            android:text="기본정보"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_small"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="@id/match_info_process_one"
-            app:layout_constraintStart_toStartOf="@+id/match_info_process_one"
-            app:layout_constraintTop_toBottomOf="@id/match_info_process_one" />
-
-        <TextView
-            android:id="@+id/match_info_process_two"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginHorizontal="@dimen/margin_xlarge"
-            android:background="@drawable/match_process_unselected"
-            android:gravity="center"
-            android:text="2"
-            android:textAlignment="center"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_medium"
-            app:layout_constraintBottom_toBottomOf="@+id/match_info_top_bar"
-            app:layout_constraintEnd_toStartOf="@id/match_info_process_three"
-            app:layout_constraintStart_toEndOf="@+id/match_info_process_one"
-            app:layout_constraintTop_toBottomOf="@+id/match_info_title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_xsmall"
-            android:text="참가자"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_small"
-            app:layout_constraintEnd_toEndOf="@id/match_info_process_two"
-            app:layout_constraintStart_toStartOf="@+id/match_info_process_two"
-            app:layout_constraintTop_toBottomOf="@id/match_info_process_two" />
-
-        <TextView
-            android:id="@+id/match_info_process_three"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="@drawable/match_process_unselected"
-            android:gravity="center"
-            android:text="3"
-            android:textAlignment="center"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_medium"
-            app:layout_constraintBottom_toBottomOf="@+id/match_info_top_bar"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/match_info_process_two"
-            app:layout_constraintTop_toBottomOf="@+id/match_info_title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_xsmall"
-            android:text="대진표작성"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_small"
-            app:layout_constraintEnd_toEndOf="@id/match_info_process_three"
-            app:layout_constraintStart_toStartOf="@+id/match_info_process_three"
-            app:layout_constraintTop_toBottomOf="@id/match_info_process_three" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/match_info_top_bar">
+        app:layout_constraintTop_toTopOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/match_info_card"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/margin_default"
-            android:paddingBottom="@dimen/bottom_app_bar_height">
+            android:layout_height="wrap_content">
 
-            <TextView
-                android:id="@+id/match_info_name_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_xsmall"
-                android:text="대회명"
-                android:textColor="@color/black"
-                android:textSize="@dimen/text_large"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <EditText
-                android:id="@+id/match_info_name_input"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/match_info_top_bar"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:background="@drawable/match_edittext"
-                android:hint="대회명을 입력해주세요."
-                android:inputType="text"
-                android:padding="@dimen/padding_medium"
-                android:textSize="@dimen/text_large"
-                app:layout_constraintTop_toBottomOf="@+id/match_info_name_title" />
-
-            <TextView
-                android:id="@+id/match_info_name_hint_one"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_small"
-                android:background="@drawable/match_hint_button"
-                android:paddingHorizontal="@dimen/margin_small"
-                android:paddingVertical="@dimen/margin_xsmall"
-                android:text="2024-07-08 (월)"
-                android:textColor="@color/black"
-                android:textSize="@dimen/text_small"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/match_info_name_input" />
-
-            <TextView
-                android:id="@+id/match_info_name_hint_two"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/margin_small"
-                android:background="@drawable/match_hint_button"
-                android:paddingHorizontal="@dimen/margin_small"
-                android:paddingVertical="@dimen/margin_xsmall"
-                android:text="2024-07 월례대회"
-                android:textColor="@color/black"
-                android:textSize="@dimen/text_small"
-                app:layout_constraintStart_toEndOf="@id/match_info_name_hint_one"
-                app:layout_constraintTop_toBottomOf="@+id/match_info_name_input" />
-
-            <TextView
-                android:id="@+id/match_info_date_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_xsmall"
-                android:layout_marginTop="@dimen/margin_default"
-                android:text="대회일자"
-                android:textColor="@color/black"
-                android:textSize="@dimen/text_large"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_info_name_hint_two" />
-
-            <!--            날짜 전용 스피너라던지 나중에 바꿔야 함.-->
-            <EditText
-                android:id="@+id/match_info_date_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:background="@drawable/match_edittext"
-                android:hint="2024-07-08"
-                android:inputType="datetime"
-                android:padding="@dimen/padding_medium"
-                android:textSize="@dimen/text_large"
-                app:layout_constraintTop_toBottomOf="@+id/match_info_date_title" />
-
-            <TextView
-                android:id="@+id/match_info_score_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_xsmall"
-                android:layout_marginTop="@dimen/margin_default"
-                android:text="승점"
-                android:textColor="@color/black"
-                android:textSize="@dimen/text_large"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_info_date_input" />
-
-            <LinearLayout
-                android:id="@+id/match_info_score_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:orientation="horizontal"
-                android:paddingHorizontal="10dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_info_score_title">
+                android:layout_height="@dimen/match_main_top_view_height"
+                android:background="@color/main"
+                app:layout_constraintTop_toTopOf="parent">
 
                 <TextView
-                    android:id="@+id/match_info_score_win"
-                    android:layout_width="0dp"
+                    android:id="@+id/match_info_title"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="승"
-                    android:textAlignment="center"
-                    android:textColor="@color/black"
-                    android:textSize="@dimen/text_large" />
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:text="대진표 생성"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_2xlarge"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/white"
+                    app:layout_constraintBottom_toBottomOf="@id/match_info_top_bar"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_title" />
 
-                <EditText
-                    android:id="@+id/match_info_score_win_input"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:autofillHints="1"
-                    android:background="@drawable/match_edittext"
-
-                    android:inputType="number"
-                    android:padding="@dimen/padding_medium"
+                <TextView
+                    android:id="@+id/match_info_process_one"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:background="@drawable/match_process_selected"
+                    android:gravity="center"
                     android:text="1"
                     android:textAlignment="center"
-                    android:textSize="@dimen/text_large" />
+                    android:textColor="@color/main"
+                    android:textSize="@dimen/text_medium"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="@+id/match_info_top_bar"
+                    app:layout_constraintEnd_toStartOf="@+id/match_info_process_two"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/match_info_title" />
 
                 <TextView
-                    android:id="@+id/match_info_score_draw"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="무"
-                    android:textAlignment="center"
-                    android:textColor="@color/black"
-                    android:textSize="@dimen/text_large" />
-
-
-                <EditText
-                    android:id="@+id/match_info_score_draw_input"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:autofillHints="0"
-                    android:background="@drawable/match_edittext"
-                    android:inputType="number"
-                    android:padding="@dimen/padding_medium"
-                    android:text="0"
-                    android:textAlignment="center"
-                    android:textSize="@dimen/text_large" />
-
-                <TextView
-                    android:id="@+id/match_info_score_lose"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="패"
-                    android:textAlignment="center"
-                    android:textColor="@color/black"
-                    android:textSize="@dimen/text_large" />
-
-
-                <EditText
-                    android:id="@+id/match_info_score_lose_input"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:autofillHints="0"
-                    android:background="@drawable/match_edittext"
-                    android:inputType="number"
-                    android:padding="@dimen/padding_medium"
-                    android:text="0"
-                    android:textAlignment="center"
-                    android:textSize="@dimen/text_large" />
-
-            </LinearLayout>
-            >
-
-            <TextView
-                android:id="@+id/match_info_game_count_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_xsmall"
-                android:layout_marginTop="@dimen/margin_default"
-                android:text="1인당 경기 수"
-                android:textColor="@color/black"
-                android:textSize="@dimen/text_large"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_info_score_input" />
-
-            <LinearLayout
-                android:id="@+id/match_info_game_count_input"
-                android:layout_width="@dimen/match_info_game_count"
-                android:layout_height="@dimen/small_button_height"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:orientation="horizontal"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_info_game_count_title">
-
-                <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/match_info_game_count_minus"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:background="@drawable/match_game_count_minus"
-                    android:padding="0dp"
-                    android:text="-"
-                    android:textColor="@color/main"
-                    android:textSize="@dimen/text_large" />
-
-                <TextView
-                    android:id="@+id/match_info_game_count_number"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_margin="0dp"
-                    android:layout_weight="1.5"
-                    android:background="@drawable/match_game_count"
-                    android:gravity="center"
-                    android:inputType="number"
-                    android:text="4"
-                    android:textAlignment="center"
-                    android:textColor="@color/main"
-                    android:textSize="@dimen/text_large" />
-
-                <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/match_info_game_count_plus"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:background="@drawable/match_game_count_plus"
-                    android:text="+"
-                    android:textColor="@color/main"
-                    android:textSize="@dimen/text_large" />
-            </LinearLayout>
-
-            <RadioGroup
-                android:id="@+id/match_info_game_type_input"
-                android:layout_width="@dimen/match_info_game_count"
-                android:layout_height="@dimen/small_button_height"
-                android:orientation="horizontal"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/match_info_game_count_input">
-
-                <RadioButton
-                    android:id="@+id/match_info_game_type_double"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:background="@drawable/selector_radio_left"
-                    android:button="@color/transparent"
-                    android:buttonTint="@color/main"
-                    android:checked="true"
-                    android:gravity="center"
-                    android:text="복식"
+                    android:layout_marginTop="@dimen/margin_xsmall"
+                    android:text="기본정보"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/text_large" />
+                    android:textSize="@dimen/text_small"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="@id/match_info_process_one"
+                    app:layout_constraintStart_toStartOf="@+id/match_info_process_one"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_process_one" />
 
-                <RadioButton
-                    android:id="@+id/match_info_game_type_single"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:background="@drawable/selector_radio_right"
-                    android:button="@color/transparent"
-                    android:checked="false"
+                <TextView
+                    android:id="@+id/match_info_process_two"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginHorizontal="@dimen/margin_xlarge"
+                    android:background="@drawable/match_process_unselected"
                     android:gravity="center"
-                    android:text="단식"
-                    android:textColor="@color/main"
-                    android:textSize="@dimen/text_large" />
-            </RadioGroup>
+                    android:text="2"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_medium"
+                    app:layout_constraintBottom_toBottomOf="@+id/match_info_top_bar"
+                    app:layout_constraintEnd_toStartOf="@id/match_info_process_three"
+                    app:layout_constraintStart_toEndOf="@+id/match_info_process_one"
+                    app:layout_constraintTop_toBottomOf="@+id/match_info_title" />
 
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/match_info_next_button"
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/small_button_height"
-                android:layout_marginTop="@dimen/margin_xlarge"
-                android:background="@drawable/match_main_button"
-                android:text="다음"
-                android:textColor="@color/white"
-                android:textSize="@dimen/text_large"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_info_game_count_input" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_xsmall"
+                    android:text="참가자"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_small"
+                    app:layout_constraintEnd_toEndOf="@id/match_info_process_two"
+                    app:layout_constraintStart_toStartOf="@+id/match_info_process_two"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_process_two" />
+
+                <TextView
+                    android:id="@+id/match_info_process_three"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:background="@drawable/match_process_unselected"
+                    android:gravity="center"
+                    android:text="3"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_medium"
+                    app:layout_constraintBottom_toBottomOf="@+id/match_info_top_bar"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/match_info_process_two"
+                    app:layout_constraintTop_toBottomOf="@+id/match_info_title" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_xsmall"
+                    android:text="대진표작성"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_small"
+                    app:layout_constraintEnd_toEndOf="@id/match_info_process_three"
+                    app:layout_constraintStart_toStartOf="@+id/match_info_process_three"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_process_three" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/match_info_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_default"
+                android:paddingBottom="@dimen/bottom_app_bar_height"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/match_info_top_bar">
+
+                <TextView
+                    android:id="@+id/match_info_name_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_xsmall"
+                    android:text="대회명"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_large"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <EditText
+                    android:id="@+id/match_info_name_input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:background="@drawable/match_edittext"
+                    android:hint="대회명을 입력해주세요."
+                    android:inputType="text"
+                    android:padding="@dimen/padding_medium"
+                    android:textSize="@dimen/text_large"
+                    app:layout_constraintTop_toBottomOf="@+id/match_info_name_title" />
+
+                <TextView
+                    android:id="@+id/match_info_name_hint_one"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:background="@drawable/match_hint_button"
+                    android:paddingHorizontal="@dimen/margin_small"
+                    android:paddingVertical="@dimen/margin_xsmall"
+                    android:text="2024-07-08 (월)"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_small"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/match_info_name_input" />
+
+                <TextView
+                    android:id="@+id/match_info_name_hint_two"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/margin_small"
+                    android:background="@drawable/match_hint_button"
+                    android:paddingHorizontal="@dimen/margin_small"
+                    android:paddingVertical="@dimen/margin_xsmall"
+                    android:text="2024-07 월례대회"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_small"
+                    app:layout_constraintStart_toEndOf="@id/match_info_name_hint_one"
+                    app:layout_constraintTop_toBottomOf="@+id/match_info_name_input" />
+
+                <TextView
+                    android:id="@+id/match_info_date_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_xsmall"
+                    android:layout_marginTop="@dimen/margin_default"
+                    android:text="대회일자"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_large"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_name_hint_two" />
+
+                <!--            날짜 전용 스피너라던지 나중에 바꿔야 함.-->
+                <TextView
+                    android:id="@+id/match_info_date_input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:background="@drawable/match_edittext"
+                    android:text="2024-07-08"
+                    android:padding="@dimen/padding_medium"
+                    android:textSize="@dimen/text_large"
+                    app:layout_constraintTop_toBottomOf="@+id/match_info_date_title" />
+
+                <TextView
+                    android:id="@+id/match_info_score_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_xsmall"
+                    android:layout_marginTop="@dimen/margin_default"
+                    android:text="승점"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_large"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_date_input" />
+
+                <LinearLayout
+                    android:id="@+id/match_info_score_input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:orientation="horizontal"
+                    android:paddingHorizontal="10dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_score_title">
+
+                    <TextView
+                        android:id="@+id/match_info_score_win"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="승"
+                        android:textAlignment="center"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/text_large" />
+
+
+                    <EditText
+                        android:id="@+id/match_info_score_win_input"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:autofillHints="1"
+                        android:background="@drawable/match_edittext"
+
+                        android:inputType="number"
+                        android:padding="@dimen/padding_medium"
+                        android:text="1"
+                        android:textAlignment="center"
+                        android:textSize="@dimen/text_large" />
+
+                    <TextView
+                        android:id="@+id/match_info_score_draw"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="무"
+                        android:textAlignment="center"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/text_large" />
+
+
+                    <EditText
+                        android:id="@+id/match_info_score_draw_input"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:autofillHints="0"
+                        android:background="@drawable/match_edittext"
+                        android:inputType="number"
+                        android:padding="@dimen/padding_medium"
+                        android:text="0"
+                        android:textAlignment="center"
+                        android:textSize="@dimen/text_large" />
+
+                    <TextView
+                        android:id="@+id/match_info_score_lose"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="패"
+                        android:textAlignment="center"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/text_large" />
+
+
+                    <EditText
+                        android:id="@+id/match_info_score_lose_input"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:autofillHints="0"
+                        android:background="@drawable/match_edittext"
+                        android:inputType="number"
+                        android:padding="@dimen/padding_medium"
+                        android:text="0"
+                        android:textAlignment="center"
+                        android:textSize="@dimen/text_large" />
+
+                </LinearLayout>
+                >
+
+                <TextView
+                    android:id="@+id/match_info_game_count_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_xsmall"
+                    android:layout_marginTop="@dimen/margin_default"
+                    android:text="1인당 경기 수"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_large"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_score_input" />
+
+                <LinearLayout
+                    android:id="@+id/match_info_game_count_input"
+                    android:layout_width="@dimen/match_info_game_count"
+                    android:layout_height="@dimen/small_button_height"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:orientation="horizontal"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_game_count_title">
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/match_info_game_count_minus"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:background="@drawable/match_game_count_minus"
+                        android:padding="0dp"
+                        android:text="-"
+                        android:textColor="@color/main"
+                        android:textSize="@dimen/text_large" />
+
+                    <TextView
+                        android:id="@+id/match_info_game_count_number"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_margin="0dp"
+                        android:layout_weight="1.5"
+                        android:background="@drawable/match_game_count"
+                        android:gravity="center"
+                        android:inputType="number"
+                        android:text="4"
+                        android:textAlignment="center"
+                        android:textColor="@color/main"
+                        android:textSize="@dimen/text_large" />
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/match_info_game_count_plus"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:background="@drawable/match_game_count_plus"
+                        android:text="+"
+                        android:textColor="@color/main"
+                        android:textSize="@dimen/text_large" />
+                </LinearLayout>
+
+                <RadioGroup
+                    android:id="@+id/match_info_game_type_input"
+                    android:layout_width="@dimen/match_info_game_count"
+                    android:layout_height="@dimen/small_button_height"
+                    android:orientation="horizontal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/match_info_game_count_input">
+
+                    <RadioButton
+                        android:id="@+id/match_info_game_type_double"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:background="@drawable/selector_radio_left"
+                        android:button="@color/transparent"
+                        android:buttonTint="@color/main"
+                        android:checked="true"
+                        android:gravity="center"
+                        android:text="복식"
+                        android:textColor="@color/white"
+                        android:textSize="@dimen/text_large" />
+
+                    <RadioButton
+                        android:id="@+id/match_info_game_type_single"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:background="@drawable/selector_radio_right"
+                        android:button="@color/transparent"
+                        android:checked="false"
+                        android:gravity="center"
+                        android:text="단식"
+                        android:textColor="@color/main"
+                        android:textSize="@dimen/text_large" />
+                </RadioGroup>
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/match_info_next_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/small_button_height"
+                    android:layout_marginTop="@dimen/margin_xlarge"
+                    android:background="@drawable/match_main_button"
+                    android:text="다음"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_large"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/match_info_game_count_input" />
+
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/app/src/main/res/layout/fragment_match_main.xml
+++ b/app/src/main/res/layout/fragment_match_main.xml
@@ -49,100 +49,116 @@
             app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/match_main_sub_info"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/match_main_scroll_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/margin_default"
-        app:layout_constraintTop_toBottomOf="@+id/match_main_top_bar">
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/match_main_top_bar">
 
-        <TextView
-            android:id="@+id/match_main_count_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="참가 인원수 : N 명\n경기 수 : N 경기"
-            android:textColor="@color/black"
-            android:textSize="@dimen/text_large"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/match_main_edit_button"
-            android:layout_width="wrap_content"
-            android:layout_height="@dimen/small_button_height"
-            android:layout_marginEnd="@dimen/margin_small"
-            android:background="@drawable/match_sub_button"
-            android:text="대진 수정"
-            android:textColor="@color/main"
-            android:textSize="@dimen/text_medium"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/match_main_share_button"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/match_main_share_button"
-            android:layout_width="wrap_content"
-            android:layout_height="@dimen/small_button_height"
-            android:background="@drawable/match_sub_button"
-            android:text="대진 공유"
-            android:textColor="@color/main"
-            android:textSize="@dimen/text_medium"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <View
-        android:id="@+id/match_main_sub_info_divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginTop="@dimen/margin_default"
-        android:background="@color/trans_black_50"
-        app:layout_constraintTop_toBottomOf="@+id/match_main_sub_info" />
-
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/match_main_tab"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/match_main_sub_info_divider"
-        app:tabGravity="fill"
-        app:tabIndicatorColor="@color/main"
-        app:tabIndicatorFullWidth="true"
-        app:tabMode="fixed"
-        app:tabSelectedTextColor="@color/main"
-        app:tabTextColor="@color/trans_black_50">
-
-        <com.google.android.material.tabs.TabItem
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="대진표"
-            android:textSize="@dimen/text_medium" />
+            android:paddingBottom="@dimen/bottom_app_bar_height">
 
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="현재 순위"
-            android:textSize="@dimen/text_medium" />
-    </com.google.android.material.tabs.TabLayout>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/match_main_sub_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_default"
+                app:layout_constraintTop_toTopOf="parent">
 
-    <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/match_main_view_pager"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/match_main_tab" />
+                <TextView
+                    android:id="@+id/match_main_count_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="참가 인원수 : N 명\n경기 수 : N 경기"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_large"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/match_main_end_button"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/small_button_height"
-        android:layout_margin="@dimen/margin_default"
-        android:background="@drawable/match_main_button"
-        android:text="경기 종료"
-        android:textColor="@color/white"
-        android:textSize="@dimen/text_large"
-        app:layout_constraintBottom_toBottomOf="parent" />
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/match_main_edit_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/small_button_height"
+                    android:layout_marginEnd="@dimen/margin_small"
+                    android:background="@drawable/match_sub_button"
+                    android:text="대진 수정"
+                    android:textColor="@color/main"
+                    android:textSize="@dimen/text_medium"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/match_main_share_button"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/match_main_share_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/small_button_height"
+                    android:background="@drawable/match_sub_button"
+                    android:text="대진 공유"
+                    android:textColor="@color/main"
+                    android:textSize="@dimen/text_medium"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <View
+                android:id="@+id/match_main_sub_info_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginTop="@dimen/margin_default"
+                android:background="@color/trans_black_50"
+                app:layout_constraintTop_toBottomOf="@+id/match_main_sub_info" />
+
+            <com.google.android.material.tabs.TabLayout
+                android:id="@+id/match_main_tab"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@+id/match_main_sub_info_divider"
+                app:tabGravity="fill"
+                app:tabIndicatorColor="@color/main"
+                app:tabIndicatorFullWidth="true"
+                app:tabMode="fixed"
+                app:tabSelectedTextColor="@color/main"
+                app:tabTextColor="@color/trans_black_50">
+
+                <!--        <com.google.android.material.tabs.TabItem-->
+                <!--            android:layout_width="match_parent"-->
+                <!--            android:layout_height="wrap_content"-->
+                <!--            android:text="대진표"-->
+                <!--            android:textSize="@dimen/text_medium" />-->
+
+                <!--        <com.google.android.material.tabs.TabItem-->
+                <!--            android:layout_width="match_parent"-->
+                <!--            android:layout_height="wrap_content"-->
+                <!--            android:text="현재 순위"-->
+                <!--            android:textSize="@dimen/text_medium" />-->
+            </com.google.android.material.tabs.TabLayout>
+
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/match_main_view_pager"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toBottomOf="@+id/match_main_tab" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/match_main_end_button"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/small_button_height"
+                android:layout_marginHorizontal="@dimen/margin_default"
+                android:layout_marginTop="@dimen/margin_2xlarge"
+                android:background="@drawable/match_main_button"
+                android:text="경기 종료"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_large"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/match_main_view_pager" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_match_main_list.xml
+++ b/app/src/main/res/layout/fragment_match_main_list.xml
@@ -1,8 +1,90 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/match_main_list_recycler_view"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@color/white" />
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    tools:context=".ui.fragments.MatchMainListFragment">
+
+    <LinearLayout
+        android:id="@+id/match_main_list_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:orientation="horizontal"
+        android:paddingVertical="@dimen/padding_medium"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="순서"
+            android:textAlignment="center"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_medium" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="팀 A"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_medium" />
+        </LinearLayout>
+
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.2"
+            android:text="점수"
+            android:textAlignment="center"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_medium" />
+
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="팀 B"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_medium" />
+
+
+        </LinearLayout>
+
+
+    </LinearLayout>
+
+    <View
+        android:id="@+id/match_main_list_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/trans_black_50"
+        app:layout_constraintTop_toBottomOf="@+id/match_main_list_header" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/match_main_list_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:nestedScrollingEnabled="false"
+        android:overScrollMode="never"
+        app:layout_constraintTop_toBottomOf="@+id/match_main_list_divider" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_match_main_rank.xml
+++ b/app/src/main/res/layout/fragment_match_main_rank.xml
@@ -3,94 +3,97 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/match_main_rank_root"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@color/white">
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    tools:context=".ui.fragments.MatchMainRankFragment">
 
-<LinearLayout
-    android:id="@+id/match_main_rank_header"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:paddingVertical="@dimen/padding_medium"
-    app:layout_constraintTop_toTopOf="parent">
-
-    <TextView
-        android:layout_width="0dp"
+    <LinearLayout
+        android:id="@+id/match_main_rank_header"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:text="순위"
-        android:textColor="@color/black"
-        android:textSize="@dimen/text_medium" />
+        android:orientation="horizontal"
+        android:paddingVertical="@dimen/padding_medium"
+        app:layout_constraintTop_toTopOf="parent">
 
-    <TextView
-        android:layout_width="0dp"
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="순위"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_medium" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="2"
+            android:gravity="center"
+            android:text="이름"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_medium" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="승"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_medium" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="무"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_medium" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="패"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_medium" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="승점"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_medium" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="득실"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_medium" />
+    </LinearLayout>
+
+    <View
+        android:id="@+id/match_main_rank_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/trans_black_50"
+        app:layout_constraintTop_toBottomOf="@+id/match_main_rank_header" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/match_main_rank_recycler_view"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="2"
-        android:gravity="center"
-        android:text="이름"
-        android:textColor="@color/black"
-        android:textSize="@dimen/text_medium" />
-
-    <TextView
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:text="승"
-        android:textColor="@color/black"
-        android:textSize="@dimen/text_medium" />
-
-    <TextView
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:text="무"
-        android:textColor="@color/black"
-        android:textSize="@dimen/text_medium" />
-
-    <TextView
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:text="패"
-        android:textColor="@color/black"
-        android:textSize="@dimen/text_medium" />
-
-    <TextView
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:text="승점"
-        android:textColor="@color/black"
-        android:textSize="@dimen/text_medium" />
-
-    <TextView
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:text="득실"
-        android:textColor="@color/black"
-        android:textSize="@dimen/text_medium" />
-</LinearLayout>
-
-<View
-    android:id="@+id/match_main_rank_divider"
-    android:layout_width="match_parent"
-    android:layout_height="1dp"
-    android:background="@color/trans_black_50"
-    app:layout_constraintTop_toBottomOf="@+id/match_main_rank_header" />
-
-<androidx.recyclerview.widget.RecyclerView
-    android:id="@+id/match_main_rank_recycler_view"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:layout_constraintTop_toBottomOf="@+id/match_main_rank_divider" />
+        app:layout_constraintTop_toBottomOf="@+id/match_main_rank_divider" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_match_player.xml
+++ b/app/src/main/res/layout/fragment_match_player.xml
@@ -10,201 +10,208 @@
     android:background="@color/white"
     tools:context=".ui.fragments.MatchPlayerFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/match_player_top_bar"
-        android:layout_width="match_parent"
-        android:layout_height="160dp"
-        android:background="@color/main"
-        app:layout_constraintTop_toTopOf="parent">\
-
-        <TextView
-            android:id="@+id/match_player_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_medium"
-            android:text="대진표 생성"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_2xlarge"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/white"
-            app:layout_constraintBottom_toBottomOf="@id/match_player_top_bar"
-            app:layout_constraintTop_toBottomOf="@id/match_player_title" />
-
-        <TextView
-            android:id="@+id/match_player_process_one"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="@drawable/match_process_unselected"
-            android:gravity="center"
-            android:text="1"
-            android:textAlignment="center"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_medium"
-            app:layout_constraintBottom_toBottomOf="@+id/match_player_top_bar"
-            app:layout_constraintEnd_toStartOf="@+id/match_player_process_two"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/match_player_title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_xsmall"
-            android:text="기본정보"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_small"
-            app:layout_constraintEnd_toEndOf="@id/match_player_process_one"
-            app:layout_constraintStart_toStartOf="@+id/match_player_process_one"
-            app:layout_constraintTop_toBottomOf="@id/match_player_process_one" />
-
-        <TextView
-            android:id="@+id/match_player_process_two"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginHorizontal="@dimen/margin_xlarge"
-            android:background="@drawable/match_process_selected"
-            android:gravity="center"
-            android:text="2"
-            android:textAlignment="center"
-            android:textColor="@color/main"
-            android:textSize="@dimen/text_medium"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="@+id/match_player_top_bar"
-            app:layout_constraintEnd_toStartOf="@id/match_player_process_three"
-            app:layout_constraintStart_toEndOf="@+id/match_player_process_one"
-            app:layout_constraintTop_toBottomOf="@+id/match_player_title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_xsmall"
-            android:text="참가자"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_small"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="@id/match_player_process_two"
-            app:layout_constraintStart_toStartOf="@+id/match_player_process_two"
-            app:layout_constraintTop_toBottomOf="@id/match_player_process_two" />
-
-        <TextView
-            android:id="@+id/match_player_process_three"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="@drawable/match_process_unselected"
-            android:gravity="center"
-            android:text="3"
-            android:textAlignment="center"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_medium"
-            app:layout_constraintBottom_toBottomOf="@+id/match_player_top_bar"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/match_player_process_two"
-            app:layout_constraintTop_toBottomOf="@+id/match_player_title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_xsmall"
-            android:text="대진표작성"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_small"
-            app:layout_constraintEnd_toEndOf="@id/match_player_process_three"
-            app:layout_constraintStart_toStartOf="@+id/match_player_process_three"
-            app:layout_constraintTop_toBottomOf="@id/match_player_process_three" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/match_player_top_bar">
+        app:layout_constraintTop_toTopOf="parent">
 
-        <com.kuneosu.mintoners.ui.customview.CustomConstraint
-            android:id="@+id/match_player_card"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/bottom_app_bar_height">
-
+            android:layout_height="wrap_content">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/match_player_card_title"
+                android:id="@+id/match_player_top_bar"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/margin_default"
+                android:layout_height="160dp"
+                android:background="@color/main"
                 app:layout_constraintTop_toTopOf="parent">
 
                 <TextView
-                    android:id="@+id/match_player_count_text"
+                    android:id="@+id/match_player_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="참가 인원수 : N 명"
-                    android:textColor="@color/black"
-                    android:textSize="@dimen/text_large"
-                    app:layout_constraintBottom_toBottomOf="@+id/match_player_load_button"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:text="대진표 생성"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_2xlarge"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/match_player_load_button" />
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/white"
+                    app:layout_constraintBottom_toBottomOf="@id/match_player_top_bar"
+                    app:layout_constraintTop_toBottomOf="@id/match_player_title" />
+
+                <TextView
+                    android:id="@+id/match_player_process_one"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:background="@drawable/match_process_unselected"
+                    android:gravity="center"
+                    android:text="1"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_medium"
+                    app:layout_constraintBottom_toBottomOf="@+id/match_player_top_bar"
+                    app:layout_constraintEnd_toStartOf="@+id/match_player_process_two"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/match_player_title" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_xsmall"
+                    android:text="기본정보"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_small"
+                    app:layout_constraintEnd_toEndOf="@id/match_player_process_one"
+                    app:layout_constraintStart_toStartOf="@+id/match_player_process_one"
+                    app:layout_constraintTop_toBottomOf="@id/match_player_process_one" />
+
+                <TextView
+                    android:id="@+id/match_player_process_two"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginHorizontal="@dimen/margin_xlarge"
+                    android:background="@drawable/match_process_selected"
+                    android:gravity="center"
+                    android:text="2"
+                    android:textAlignment="center"
+                    android:textColor="@color/main"
+                    android:textSize="@dimen/text_medium"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="@+id/match_player_top_bar"
+                    app:layout_constraintEnd_toStartOf="@id/match_player_process_three"
+                    app:layout_constraintStart_toEndOf="@+id/match_player_process_one"
+                    app:layout_constraintTop_toBottomOf="@+id/match_player_title" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_xsmall"
+                    android:text="참가자"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_small"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="@id/match_player_process_two"
+                    app:layout_constraintStart_toStartOf="@+id/match_player_process_two"
+                    app:layout_constraintTop_toBottomOf="@id/match_player_process_two" />
+
+                <TextView
+                    android:id="@+id/match_player_process_three"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:background="@drawable/match_process_unselected"
+                    android:gravity="center"
+                    android:text="3"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_medium"
+                    app:layout_constraintBottom_toBottomOf="@+id/match_player_top_bar"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/match_player_process_two"
+                    app:layout_constraintTop_toBottomOf="@+id/match_player_title" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_xsmall"
+                    android:text="대진표작성"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_small"
+                    app:layout_constraintEnd_toEndOf="@id/match_player_process_three"
+                    app:layout_constraintStart_toStartOf="@+id/match_player_process_three"
+                    app:layout_constraintTop_toBottomOf="@id/match_player_process_three" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+            <com.kuneosu.mintoners.ui.customview.CustomConstraint
+                android:id="@+id/match_player_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="@dimen/bottom_app_bar_height"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/match_player_top_bar">
+
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/match_player_card_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/margin_default"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <TextView
+                        android:id="@+id/match_player_count_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="참가 인원수 : N 명"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/text_large"
+                        app:layout_constraintBottom_toBottomOf="@+id/match_player_load_button"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="@+id/match_player_load_button" />
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/match_player_load_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="@dimen/small_button_height"
+                        android:background="@drawable/match_main_button"
+                        android:paddingHorizontal="@dimen/padding_small"
+                        android:text="선수 불러오기"
+                        android:textColor="@color/white"
+                        android:textSize="@dimen/text_large"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <View
+                    android:id="@+id/match_player_card_title_divider"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="@dimen/margin_default"
+                    android:background="@color/trans_black_50"
+                    app:layout_constraintTop_toBottomOf="@+id/match_player_card_title" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/match_player_recycler_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toBottomOf="@id/match_player_card_title_divider" />
 
                 <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/match_player_load_button"
+                    android:id="@+id/match_player_previous_button"
                     android:layout_width="wrap_content"
                     android:layout_height="@dimen/small_button_height"
+                    android:layout_marginStart="@dimen/margin_default"
+                    android:layout_marginTop="@dimen/margin_xlarge"
+                    android:background="@drawable/match_sub_button"
+                    android:text="이전"
+                    android:textColor="@color/main"
+                    android:textSize="@dimen/text_large"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/match_player_recycler_view" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/match_player_next_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/small_button_height"
+                    android:layout_marginTop="@dimen/margin_xlarge"
+                    android:layout_marginEnd="@dimen/margin_default"
                     android:background="@drawable/match_main_button"
-                    android:paddingHorizontal="@dimen/padding_small"
-                    android:text="선수 불러오기"
+                    android:text="다음"
                     android:textColor="@color/white"
                     android:textSize="@dimen/text_large"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <View
-                android:id="@+id/match_player_card_title_divider"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginTop="@dimen/margin_default"
-                android:background="@color/trans_black_50"
-                app:layout_constraintTop_toBottomOf="@+id/match_player_card_title" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/match_player_recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@id/match_player_card_title_divider" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/match_player_previous_button"
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/small_button_height"
-                android:layout_marginStart="@dimen/margin_default"
-                android:layout_marginTop="@dimen/margin_xlarge"
-                android:background="@drawable/match_sub_button"
-                android:text="이전"
-                android:textColor="@color/main"
-                android:textSize="@dimen/text_large"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_player_recycler_view" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/match_player_next_button"
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/small_button_height"
-                android:layout_marginTop="@dimen/margin_xlarge"
-                android:layout_marginEnd="@dimen/margin_default"
-                android:background="@drawable/match_main_button"
-                android:text="다음"
-                android:textColor="@color/white"
-                android:textSize="@dimen/text_large"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/match_player_recycler_view" />
+                    app:layout_constraintTop_toBottomOf="@id/match_player_recycler_view" />
 
 
-        </com.kuneosu.mintoners.ui.customview.CustomConstraint>
+            </com.kuneosu.mintoners.ui.customview.CustomConstraint>
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 
 </com.kuneosu.mintoners.ui.customview.CustomConstraint>

--- a/app/src/main/res/layout/match_calendar_dialog.xml
+++ b/app/src/main/res/layout/match_calendar_dialog.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="330dp"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="20dp">
+
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="330dp"
+        android:layout_height="wrap_content">
+
+        <CalendarView
+            android:id="@+id/match_calendar_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toTopOf="@id/match_calendar_divider"
+            app:layout_constraintTop_toTopOf="parent" />
+
+
+        <View
+            android:id="@+id/match_calendar_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/trans_black_50"
+            app:layout_constraintBottom_toTopOf="@id/match_calendar_close"
+            app:layout_constraintTop_toBottomOf="@id/match_calendar_view" />
+
+        <TextView
+            android:id="@+id/match_calendar_close"
+            android:layout_width="330dp"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/padding_medium"
+            android:text="닫기"
+            android:textAlignment="center"
+            android:textColor="@color/trans_black_75"
+            android:textSize="@dimen/text_large"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/match_calendar_divider" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/match_calendar_dialog.xml
+++ b/app/src/main/res/layout/match_calendar_dialog.xml
@@ -10,12 +10,16 @@
         android:layout_width="330dp"
         android:layout_height="wrap_content">
 
+
         <CalendarView
             android:id="@+id/match_calendar_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toTopOf="@id/match_calendar_divider"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            android:theme="@style/CalenderViewCustom"
+            android:dateTextAppearance="@style/CalenderViewDateCustomText"
+            android:weekDayTextAppearance="@style/CalenderViewWeekCustomText" />
 
 
         <View

--- a/app/src/main/res/layout/match_main_list_item.xml
+++ b/app/src/main/res/layout/match_main_list_item.xml
@@ -24,17 +24,37 @@
             android:textColor="@color/black"
             android:textSize="@dimen/text_large" />
 
-        <TextView
-            android:id="@+id/match_main_list_team_a"
+        <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_small"
+            android:layout_height="match_parent"
             android:layout_weight="2"
-            android:padding="@dimen/padding_small"
-            android:text="김권수, 김권수"
-            android:textAlignment="center"
-            android:textColor="@color/black"
-            android:textSize="@dimen/text_medium" />
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/match_main_list_player_a"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="김권수"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_medium" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginHorizontal="@dimen/margin_medium"
+                android:background="@color/trans_black_25" />
+
+            <TextView
+                android:id="@+id/match_main_list_player_b"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="김권수"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_medium" />
+        </LinearLayout>
 
 
         <EditText
@@ -75,24 +95,44 @@
             android:textSize="@dimen/text_medium" />
 
 
-        <TextView
-            android:id="@+id/match_main_list_team_b"
+        <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_small"
+            android:layout_height="match_parent"
             android:layout_weight="2"
-            android:padding="@dimen/padding_small"
-            android:text="김권수, 김권수"
-            android:textAlignment="center"
-            android:textColor="@color/black"
-            android:textSize="@dimen/text_medium" />
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/match_main_list_player_c"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="김권수"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_medium" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginHorizontal="@dimen/margin_medium"
+                android:background="@color/trans_black_25" />
+
+            <TextView
+                android:id="@+id/match_main_list_player_d"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="김권수"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_medium" />
+        </LinearLayout>
 
 
     </LinearLayout>
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="1dp"
+        android:layout_height="3dp"
         android:background="#26000000"
         app:layout_constraintTop_toBottomOf="@id/match_main_list_info" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,8 @@
     <color name="trans_black_50">#80000000</color>
     <color name="trans_black_25">#40000000</color>
     <color name="trans_black_75">#BF000000</color>
+
+    <color name="datePrimary">#804B89DC</color>
+    <color name="dateAccent">@color/main</color>
+    <color name="dateArrow">@color/black</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -34,6 +34,7 @@
     <dimen name="home_top_view_height">300dp</dimen>
     <dimen name="home_card_height">140dp</dimen>
     <dimen name="rounded_corner_radius">90dp</dimen>
+    <dimen name="match_main_top_view_height">160dp</dimen>
     <dimen name="recent_game_recycler_height">110dp</dimen>
     <dimen name="match_making_card_height">200dp</dimen>
     <dimen name="login_button_width">337.5dp</dimen>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -17,6 +17,23 @@
         <item name="android:checkboxStyle">@style/customCheckboxFontStyle</item>
     </style>
 
+    <style name="CalenderViewCustom" parent="Theme.AppCompat">
+        <item name="colorAccent">@color/main</item>
+        <item name="colorPrimary">@color/white</item>
+        <item name="colorControlActivated">@color/main</item>
+        <item name="android:textColorPrimary">@color/black</item>
+    </style>
+
+    <style name="CalenderViewDateCustomText" parent="android:TextAppearance.DeviceDefault.Small">
+        <item name="android:textColor">@drawable/selector_match_calendar</item>
+        <item name="android:weekNumberColor">@color/black</item>
+    </style>
+
+    <style name="CalenderViewWeekCustomText" parent="android:TextAppearance.DeviceDefault.Small">
+        <item name="android:textColor">@color/main</item>
+    </style>
+
+
     <style name="BottomAppBar" parent="Theme.MaterialComponents.DayNight">
         <item name="colorPrimary">@color/main</item>
         <item name="colorPrimaryVariant">@color/white</item>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://jitpack.io")
     }
 }
 


### PR DESCRIPTION
- **Match Process 디테일 개발**
  - MatchMain 정보 출력
    - 상단바에 제목 출력
    - 서브 타이틀에 경기 수와 참가자 수 출력
  - Process 화면들 ScrollView 전체로 변경
  - CalendarView 추가
    - 대회일자를 선택할 수 있는 캘린더 뷰 추가
    - 캘린더 뷰를 통해 대회일자를 선택하면 MatchInfoFragment 에서 대회일자 자동 입력
    - 변경되는 대회 일자에 따라 Title hint 변경
    - MaterialCalendarView 는 충돌이 발생하여 일반 CalendarView 사용
    - Dialog 형식으로 출력하고 ViewModel을 통해 데이터 주고받음
  - Player, Game, Main Fragment 코드 정리
  - Game, Main Fragment에서 네비게이션이 꼬이던 문제 해결
  - MatchMainFragment 개발 완료
    - ViewPager2 를 사용한 Tab 전환
    - MatchMainListFragment, MatchMainRankFragment 연결
  - MatchMainFragment 에서 Match 데이터를 가져와서 출력
    - Match.matchList 를 가져와서 대진표 출력 (MatchMainListFragment)
    - MatchMainListItem 디자인 수정 
    - Match.players 를 가져와서 플레이어 목록 출력 (MatchMainRankFragment)
      - 각 플레이어 별 승점에 따라 정렬 기능 구현 필요.